### PR TITLE
Замена ресурсов на ванильные для приёма в станки

### DIFF
--- a/Resources/Prototypes/_Metro14/Recipec/Lathes/ammunitions.yml
+++ b/Resources/Prototypes/_Metro14/Recipec/Lathes/ammunitions.yml
@@ -3,7 +3,7 @@
   result: MagazineBoxLightRifle
   completetime: 3
   materials:
-    M14Steel: 600
+    Steel: 600
     M14Gunpowder: 600
 
 - type: latheRecipe
@@ -11,7 +11,7 @@
   result: BoxLethalshot
   completetime: 3
   materials:
-    M14Steel: 400
+    Steel: 400
     M14Gunpowder: 400
 
 - type: latheRecipe
@@ -19,7 +19,7 @@
   result: ShellShotgun
   completetime: 0.1
   materials:
-    M14Steel: 1
+    Steel: 1
     M14Gunpowder: 1
 
 - type: latheRecipe
@@ -27,7 +27,7 @@
   result: CartridgeLightRifle
   completetime: 0.1
   materials:
-    M14Steel: 15
+    Steel: 15
     M14Gunpowder: 1
 
 - type: latheRecipe
@@ -35,7 +35,7 @@
   result: BoxShotgunSlug
   completetime: 3
   materials:
-    M14Steel: 400
+    Steel: 400
     M14Gunpowder: 400
 
 - type: latheRecipe
@@ -43,5 +43,5 @@
   result: ShellShotgunSlug
   completetime: 0.1
   materials:
-    M14Steel: 1
+    Steel: 1
     M14Gunpowder: 1

--- a/Resources/Prototypes/_Metro14/Recipec/Lathes/armor.yml
+++ b/Resources/Prototypes/_Metro14/Recipec/Lathes/armor.yml
@@ -3,38 +3,38 @@
   result: M14ClothingOuterArmorPlateStalker
   completetime: 4
   materials:
-    M14Steel: 300
-    M14Cloth: 500
+    Steel: 300
+    Cloth: 500
 
 - type: latheRecipe
   id: ClothingHeadHatHardhatWhite
   result: ClothingHeadHatHardhatWhite
   completetime: 2
   materials:
-    M14Glass: 300
-    M14Plastic: 900
+    Glass: 300
+    Plastic: 900
 
 - type: latheRecipe
   id: Floodlight
   result: Floodlight
   completetime: 15
   materials:
-    M14Glass: 900
-    M14Steel: 1200
+    Glass: 900
+    Steel: 1200
 
 - type: latheRecipe
   id: M14ClothingOuterArmorPlateHeavy
   result: M14ClothingOuterArmorPlateHeavy
   completetime: 1
   materials:
-    M14Plastic: 900
-    M14Steel: 1900
-    M14Cloth: 500
+    Plastic: 900
+    Steel: 1900
+    Cloth: 500
 
 - type: latheRecipe
   id: M14ClothingOuterArmor6b13
   result: M14ClothingOuterArmor6b13
   completetime: 1
   materials:
-    M14Plastic: 900
-    M14Steel: 1400
+    Plastic: 900
+    Steel: 1400

--- a/Resources/Prototypes/_Metro14/Recipec/Lathes/devices.yml
+++ b/Resources/Prototypes/_Metro14/Recipec/Lathes/devices.yml
@@ -3,5 +3,5 @@
   result: M14NightVisionDeviceHud
   completetime: 70
   materials:
-    M14Steel: 1000
-    M14ReinforcedGlass: 300
+    Steel: 1000
+    ReinforcedGlass: 300

--- a/Resources/Prototypes/_Metro14/Recipec/Lathes/magazines.yml
+++ b/Resources/Prototypes/_Metro14/Recipec/Lathes/magazines.yml
@@ -3,11 +3,11 @@
   result: MagazineLightRifle
   completetime: 3
   materials:
-    M14Steel: 1900
+    Steel: 1900
 
 - type: latheRecipe
   id: M14MagazineLightRifleExtended
   result: M14MagazineLightRifleExtended
   completetime: 4
   materials:
-    M14Steel: 2200
+    Steel: 2200

--- a/Resources/Prototypes/_Metro14/Recipec/Lathes/weapons.yml
+++ b/Resources/Prototypes/_Metro14/Recipec/Lathes/weapons.yml
@@ -3,37 +3,37 @@
   result: M14WeaponRifleAk74
   completetime: 30
   materials:
-    M14Steel: 1500
-    M14Wood: 500
+    Steel: 1500
+    Wood: 500
 
 - type: latheRecipe
   id: M14WeaponShotgunAshot
   result: M14WeaponShotgunAshot
   completetime: 10
   materials:
-    M14Steel: 350
-    M14Wood: 100
+    Steel: 350
+    Wood: 100
 
 - type: latheRecipe
   id: M14WeaponShotgunDuplet
   result: M14WeaponShotgunDuplet
   completetime: 20
   materials:
-    M14Steel: 1000
-    M14Wood: 250
+    Steel: 1000
+    Wood: 250
 
 - type: latheRecipe
   id: M14WeaponSniperMosin
   result: M14WeaponSniperMosin
   completetime: 15
   materials:
-    M14Steel: 1250
-    M14Wood: 1000
+    Steel: 1250
+    Wood: 1000
 
 - type: latheRecipe
   id: M14Weaponak12
   result: M14Weaponak12
   completetime: 60
   materials:
-    M14Steel: 1850
-    M14Plasteel: 800
+    Steel: 1850
+    Plasteel: 800


### PR DESCRIPTION
Папка прототипы слетела из-за перехода на подмодули, вследствие чего 88ой ПР так же слетел. Теперь верстак так же обратно хавает ток ванильные ресы и делает только за ванильные ресы.